### PR TITLE
Fixed typographical error, changed aggresive to aggressive in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Hacker news in your terminal.
 
 .. image:: https://raw.github.com/socketubs/pyhn/master/screenshot.png
 
-Don't be worry about your IP. Pyhn is not aggresive, it uses cache.
+Don't be worry about your IP. Pyhn is not aggressive, it uses cache.
 
 * ``Cache manager``
 * ``Customize all the colors``


### PR DESCRIPTION
@socketubs, I've corrected a typographical error in the documentation of the [pyhn](https://github.com/socketubs/pyhn) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.